### PR TITLE
Add Agent Skills: somnia + dreamdex-bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ competition.
 | [`advanced/batch-7702`](advanced/batch-7702) | A **technique demo** (not a trading strategy): how to use EIP-7702 to batch multiple actions into a single transaction. |
 | [`tools/edge-analytics`](tools/edge-analytics) | An **analysis tool** (not a bot): measures whether a maker actually has an edge — captured spread vs adverse selection vs transactions-per-fill — from your own fills. Methodology in [docs/measuring-edge.md](docs/measuring-edge.md). |
 | [`examples/`](examples) | The real competition bots, sanitized to core code. Different architectures, languages, and tricks — read them to see how people actually did it. |
+| [`skills/`](skills) | [Agent Skills](skills) so an AI coding agent can build DreamDEX bots with the right context: a general [`somnia`](skills/somnia) skill and a [`dreamdex-bot`](skills/dreamdex-bot) skill (the core API, gotchas, and session keys). |
 
 ## The one thing to know before you start
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DreamDEX Bot Kit
+# dreamBot Kit
 
 Build automated trading bots on [DreamDEX](https://docs.dreamdex.io) — the on-chain
 central-limit order book (CLOB) on [Somnia](https://somnia.network). This kit gives you a

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,15 @@
+# Agent Skills
+
+[Agent Skills](https://docs.claude.com/en/docs/claude-code/skills) that give an
+AI coding agent the context to build on Somnia and DreamDEX. Each skill is a
+folder with a `SKILL.md` (name + description + instructions).
+
+| Skill | Use it for |
+| --- | --- |
+| [`somnia`](somnia) | Connecting to Somnia: chain IDs, RPCs, native SOMI gas, USDso decimals, SIWE. |
+| [`dreamdex-bot`](dreamdex-bot) | Building/​debugging trading bots on DreamDEX: the core API, the order-placement gotchas, session keys, and edge measurement. |
+
+**Using them:** point an agent (e.g. Claude Code) at this repo, or copy a skill
+folder into your agent's skills directory. The `dreamdex-bot` skill references the
+kit's `packages/core` API and the `docs/` for detail, so it works best alongside
+the rest of the repo.

--- a/skills/dreamdex-bot/SKILL.md
+++ b/skills/dreamdex-bot/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: dreamdex-bot
+description: >-
+  Build, run, and debug automated trading bots on DreamDEX — Somnia's on-chain
+  central limit order book (CLOB) — using this kit. Use when writing or fixing a
+  market-making, grid, momentum, TWAP, mean-reversion, or arbitrage bot, placing
+  or cancelling orders on a DreamDEX SpotPool, handling order-placement gotchas,
+  wiring session-key/operator trading, or measuring whether fills are toxic.
+---
+
+# Building trading bots on DreamDEX
+
+DreamDEX is a fully on-chain central limit order book (CLOB) on Somnia. This kit
+(`@dreamdex-bot-kit/core`, plus strategy templates) handles the DreamDEX-specific
+mechanics so a bot only expresses its logic. Prefer the kit's `Pool` API over
+touching raw ABIs or units — it quantizes to tick/lot and routes through a safe
+place/cancel lifecycle.
+
+Read the network basics from the **`somnia`** skill first (chain IDs, native
+SOMI, USDso 18 decimals).
+
+## Setup
+
+```bash
+npm install
+cp .env.example .env         # set PRIVATE_KEY; keep NETWORK=testnet to start
+npm run dev -w market-making # runs DRY_RUN by default — logs orders, sends nothing
+```
+
+Env vars read by core: `PRIVATE_KEY` (funded key), `NETWORK` (`testnet` |
+`mainnet`), optional `RPC_URL`, optional `OWNER_ADDRESS` (session-key mode, below).
+Every strategy defaults to `DRY_RUN=true`; flip to `false` only after watching it.
+
+## Core API
+
+```ts
+import { createChainContext, Pool, ORDER_TYPE } from "@dreamdex-bot-kit/core";
+
+const ctx = createChainContext();                 // reads PRIVATE_KEY + NETWORK
+const pool = await Pool.load(ctx, "SOMI:USDso");  // markets: SOMI:USDso, WETH:USDso, WBTC:USDso, USDC.e:USDso
+
+const { bestBid, bestAsk, mid } = await pool.topOfBook();
+
+// PostOnly maker quote (never crosses; rejected if it would take):
+await pool.place({ isBid: true, price: mid! * 0.999, qty: 1, orderType: ORDER_TYPE.PostOnly });
+
+// IOC taker that actually crosses (price THROUGH the touch, see gotchas):
+await pool.place({ isBid: true, price: bestAsk! * 1.0005, qty: 1, orderType: ORDER_TYPE.ImmediateOrCancel });
+
+await pool.cancel(orderId);
+const invBase = await pool.walletBase();  // live inventory (see the auto-pull gotcha)
+```
+
+`ORDER_TYPE`: `Normal` = 0 (GTC, rests), `FillOrKill` = 1, `ImmediateOrCancel` = 2
+(taker default), `PostOnly` = 3 (maker-only). Python mirror: `from dreamdex_core
+import Pool, OrderType` — same shape, snake_case.
+
+## Gotchas (these silently reject or revert — get them right)
+
+1. **`placeOrder` is the only entry point.** The old `placeTakerOrderWithoutVault`
+   was removed in the June 2026 spot upgrade. `placeOrder` is `payable`; wallet
+   auto-pull is the default; native input goes in `msg.value`.
+2. **`expireTimestampNs` must be a FUTURE nanosecond timestamp.** `0`, past, or
+   now are all rejected — there is no "never expires" sentinel. Use
+   `(Date.now() + lifetimeMs) * 1_000_000`.
+3. **`price = 0` never crosses** — it's a literal limit price of zero, not
+   "market". Price takers a few bps *through* the touch (buy ≥ ask, sell ≤ bid);
+   even +1 tick often fails to cross on a fast tape.
+4. **Native SOMI buys need ≥ 5,000,000 gas** (payout gas-headroom guard); native
+   cancels need a high limit too. **Simulate at the same gas limit you broadcast.**
+5. **Native SOMI is a sentinel**, not `address(0)`:
+   `0x28f34DeFd2b4CB48d9eE6d89f2Be4Bc601694c00`.
+6. **A mined tx can be a silent rejection.** `placeOrder` returns `(success,
+   orderId)`; `success=false` does NOT revert. Simulate first (`eth_call`), and
+   after mining confirm an `OrderPlaced` log exists; read the real `orderId` from
+   the receipt, not the simulation.
+7. **`getPoolParams()` returns 7 fields** in order: `baseToken, quoteToken,
+   makerFee, takerFee, tickSize, minQuantity, lotSize` (minQuantity before
+   lotSize). Quantize price to `tickSize`, qty to `lotSize`, qty ≥ `minQuantity`.
+8. **Pin the `OrderFilled` topic0** — it gained `fillPrice` (now 6 args) in the
+   June 2026 upgrade, so a hand-rolled signature hash won't match. Use
+   `0xc87f4223e9e7c4e4f39f9b34fc9d64d78cdb95d9035b3748cbde59521261a399`.
+9. **`getBookLevels` returns `[]` on an empty book — it does NOT revert.** Don't
+   wrap it in a broad try/catch that would mask real RPC/ABI errors as "empty".
+10. **Inventory settles to the WALLET.** In the default auto-pull/auto-deliver
+    mode, fills land in your wallet and the vault reads ~0 — read inventory with
+    `pool.walletBase()` (ERC-20 `balanceOf`, or native balance for SOMI), not the
+    vault, unless you explicitly ran `setManualVaultMode(true)`.
+11. **USDso is 18 decimals.** Read decimals; never assume 6.
+12. **REST (`/v0/trades`, order book) can lag or stall.** For fills/PnL/inventory,
+    read `OrderFilled` on-chain; treat REST snapshots as approximate.
+13. **Builder codes are enabled on mainnet (1% cap), 0 on testnet.** This kit
+    trades **untagged** (`builder = address(0)`), which is valid on both.
+
+Most of these are guarded for you in `packages/core/src/gotchas.ts` +
+`execute.ts`. Full prose: `docs/gotchas.md`.
+
+## Session keys (operator / split-key)
+
+Trade from a hot **operator** key that can place/cancel but **never withdraw
+funds** — the owner key stays cold. Set `OWNER_ADDRESS` and `createChainContext`
+uses the operator to call `placeOrderFor` / `cancelOrderFor` on the owner's
+behalf. Grant per-selector permissions via the OperatorPermissionsRegistry;
+`scripts/operator-setup.ts` wires it end-to-end. See `docs/session-keys.md`.
+
+## Strategy templates
+
+Ready-to-adapt strategies on top of core (in `strategies/`): **market-making**
+(PostOnly two-sided with inventory skew; TS + Python), **grid**, **momentum**,
+**twap**, **mean-reversion**. Each has its own README and env knobs (e.g.
+`MM_SYMBOL`, `MM_HALF_SPREAD_BPS`, `MM_NOTIONAL_USDSO`, `MM_INVENTORY_SKEW_BPS`).
+Advanced: `advanced/batch-7702` (EIP-7702 transaction batching).
+
+## Does the bot actually have an edge?
+
+Volume alone isn't profit — a maker only wins if captured spread > adverse
+selection. Run `tools/edge-analytics` over your own fills to measure captured
+spread vs. adverse-selection drift vs. gas (the Glosten–Milgrom inequality) and
+get a go/no-go verdict. Methodology: `docs/measuring-edge.md`.
+
+## Operating a bot 24/7
+
+Serialize sends through one nonce (native single-key, or the core NonceManager
+for pipelining), keep a SOMI gas buffer, use a drawdown/gas risk stop, and add a
+watchdog that restarts on idle. See `docs/24-7-operations.md`.
+
+> Educational tooling, not financial advice — see `DISCLAIMER.md`. Test on
+> testnet with small size before mainnet.

--- a/skills/somnia/SKILL.md
+++ b/skills/somnia/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: somnia
+description: >-
+  Reference for the Somnia blockchain — an EVM-compatible high-performance L1.
+  Use when connecting to Somnia, configuring an RPC/chain ID, reasoning about
+  the native SOMI gas token, USDso, or deploying/reading contracts on Somnia
+  mainnet or the Shannon testnet.
+---
+
+# Somnia
+
+Somnia is an EVM-compatible, high-performance Layer 1. Everything works like
+Ethereum (same JSON-RPC, same tooling — viem, ethers, web3.py, Foundry, Hardhat),
+so build as you would for any EVM chain and just point it at the right network.
+
+## Networks
+
+| Network | chainId | RPC | Explorer |
+| --- | --- | --- | --- |
+| **Mainnet** | `5031` | `https://api.infra.mainnet.somnia.network` | `https://explorer.somnia.network` |
+| **Shannon Testnet** | `50312` | `https://dream-rpc.somnia.network` | `https://shannon-explorer.somnia.network` |
+
+Always develop and test on **testnet first**, then switch the network for mainnet.
+
+## The gas token: native SOMI
+
+- The chain's native/gas token is **SOMI** — it pays for gas, exactly like ETH on
+  Ethereum. Keep a SOMI balance in any account that sends transactions.
+- SOMI has **no ERC-20 contract**. When a protocol needs to reference "native" as
+  a token address, it uses a sentinel, **not** `address(0)`. On DreamDEX that
+  sentinel is `0x28f34DeFd2b4CB48d9eE6d89f2Be4Bc601694c00`. Read a native balance
+  with the standard RPC `eth_getBalance`, not an ERC-20 `balanceOf`.
+- Operations that deliver native SOMI to a recipient can need a **higher gas
+  limit** than a plain ERC-20 transfer (the payout path runs a gas-headroom
+  guard). If a native-delivering call reverts, raise the gas limit and re-simulate
+  at the same limit you broadcast.
+
+## Tokens & decimals
+
+Never hard-code token decimals — read them from the contract/API. On Somnia,
+notably **USDso (the DreamDEX quote stablecoin) is 18 decimals**, not the
+6-decimal USDC convention. Assuming 6 will misprice everything by 10^12.
+
+## Signing / SIWE
+
+If a Somnia dApp uses Sign-In With Ethereum (SIWE), the `Chain ID` in the signed
+message **must match the network** you're transacting on (`5031` mainnet /
+`50312` testnet). A mismatch causes intermittent auth failures.
+
+## Building on Somnia
+
+Because it's EVM-equivalent, standard workflows apply:
+
+- **Wallets / RPC:** add the network above to MetaMask, viem, ethers, or web3.py.
+- **Contracts:** deploy with Foundry or Hardhat targeting the Somnia RPC.
+- **Reads/events:** `eth_call`, logs, and topic filters behave as on Ethereum.
+
+For trading on **DreamDEX** (Somnia's on-chain CLOB) specifically, use the
+companion **`dreamdex-bot`** skill in this repo — it covers the exchange contract
+surface, the DreamDEX-specific gotchas, and the bot toolkit.


### PR DESCRIPTION
Adds a `skills/` folder with two [Agent Skills](https://docs.claude.com/en/docs/claude-code/skills) so an AI coding agent can build on Somnia/DreamDEX with the right context:

- **`skills/somnia`** — network reference: chain IDs (5031 / 50312), RPCs, native SOMI gas, USDso decimals, SIWE.
- **`skills/dreamdex-bot`** — the flagship: the core `Pool` API, the order-placement gotchas, session-key/operator trading, the strategy templates, and edge measurement. Distilled from `packages/core` + `docs/`.

Plus a `skills/README.md` index and a row in the main README's "What's inside".

Docs-only (no code changes); `@license` headers not required for markdown. Fits the agentic-chain direction — participants can point an agent at the repo and build a bot.