### PR TITLE
Add Railway worker template for one-click bot deploys

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+dist
+.git
+.cursor
+.env
+.env.*
+!.env.example
+examples
+tools
+skills
+packages/core-py
+**/__pycache__
+**/.venv
+**/*.pyc
+*.tsbuildinfo
+.DS_Store

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@ dist
 .env
 .env.*
 !.env.example
+!.env.railway
 examples
 tools
 skills

--- a/.env.railway
+++ b/.env.railway
@@ -1,0 +1,67 @@
+# Default Railway / template variables (no secrets). Matches dreamBot Builder safe defaults.
+# Import: Railway service → Variables → RAW Editor → paste this file.
+# Set PRIVATE_KEY separately (required; never commit).
+
+STRATEGY=starter
+NETWORK=testnet
+DRY_RUN=true
+
+# ── starter ─────────────────────────────────────────────────────────────────
+SYMBOL=SOMI:USDso
+STARTER_SPREAD_BPS=10
+STARTER_SIZE_USDSO=20
+STARTER_TICK_MS=5000
+
+# ── market-making ───────────────────────────────────────────────────────────
+MM_SYMBOL=SOMI:USDso
+MM_HALF_SPREAD_BPS=5
+MM_NOTIONAL_USDSO=20
+MM_TARGET_INVENTORY_USDSO=0
+MM_INVENTORY_SKEW_BPS=4
+MM_REQUOTE_TRIGGER_BPS=3
+MM_MAX_BOOK_SPREAD_BPS=50
+MM_REQUOTE_COOLDOWN_MS=2000
+MM_REFRESH_INTERVAL_MS=5000
+
+# ── grid ────────────────────────────────────────────────────────────────────
+GRID_SYMBOL=SOMI:USDso
+GRID_STEP_BPS=30
+GRID_LOT_USDSO=15
+GRID_MAX_INVENTORY_USDSO=90
+GRID_MAX_SPREAD_BPS=60
+GRID_MAX_SESSION_LOSS_USDSO=25
+GRID_STUCK_TIMEOUT_MS=900000
+GRID_INTERVAL_MS=8000
+
+# ── momentum ──────────────────────────────────────────────────────────────
+MOM_SYMBOL=WETH:USDso
+MOM_WINDOW_SIZE=20
+MOM_ENTRY_MOMENTUM=0.008
+MOM_EXIT_MOMENTUM=0.0
+MOM_NOTIONAL_USDSO=25
+MOM_TAKE_PROFIT_PCT=0.01
+MOM_STOP_LOSS_PCT=0.006
+MOM_CROSS_BPS=8
+MOM_INTERVAL_MS=5000
+
+# ── mean-reversion ──────────────────────────────────────────────────────────
+MR_SYMBOL=WETH:USDso
+MR_WINDOW_SIZE=40
+MR_RSI_PERIOD=14
+MR_BB_PERIOD=20
+MR_BB_MULT=2
+MR_RSI_OVERSOLD=30
+MR_RSI_EXIT=52
+MR_NOTIONAL_USDSO=25
+MR_TAKE_PROFIT_PCT=0.012
+MR_STOP_LOSS_PCT=0.02
+MR_CROSS_BPS=8
+MR_INTERVAL_MS=5000
+
+# ── twap ───────────────────────────────────────────────────────────────────
+TWAP_SYMBOL=SOMI:USDso
+TWAP_SIDE=buy
+TWAP_TOTAL_USDSO=20
+TWAP_SLICES=5
+TWAP_INTERVAL_SEC=30
+TWAP_MAX_SLIPPAGE_BPS=15

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ venv/
 # os
 .DS_Store
 
+# local Cursor rules
+.cursor/
+
 # python build artifacts
 *.egg-info/
 .pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 .env
 .env.*
 !.env.example
+!.env.railway
 *.key
 keystore.json
 .state/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# DreamDEX bot worker — deploy via Railway template (see docs/railway.md).
+FROM node:20-bookworm-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY package.json package-lock.json tsconfig.base.json ./
+COPY packages packages
+COPY strategies strategies
+COPY advanced advanced
+COPY scripts scripts
+
+RUN npm ci
+
+ENV NODE_ENV=production
+
+CMD ["node", "scripts/railway-start.mjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY packages packages
 COPY strategies strategies
 COPY advanced advanced
 COPY scripts scripts
+COPY .env.railway .env
 
 RUN npm ci
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ New to all this? Read [docs/getting-started.md](docs/getting-started.md) end to 
 
 **Deploy on Railway (24/7 worker, no local Node):** see [docs/railway.md](docs/railway.md).
 
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/_qTYwR?referralCode=2yBRe7&utm_medium=integration&utm_source=template&utm_campaign=generic)
+
 ### Helper scripts
 
 Small read-only / cleanup utilities in [`scripts/`](scripts) (run with `npx tsx scripts/<name>.ts`):

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ New to all this? Read [docs/getting-started.md](docs/getting-started.md) end to 
 
 **Deploy on Railway (24/7 worker, no local Node):** see [docs/railway.md](docs/railway.md).
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/_qTYwR?referralCode=2yBRe7&utm_medium=integration&utm_source=template&utm_campaign=generic)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/_qTYwR)
 
 ### Helper scripts
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ competition.
 | --- | --- |
 | [`packages/core`](packages/core) | Shared client — auth, REST, WebSocket, order execution, gotcha guards, nonce manager. TypeScript **and** Python. Every strategy imports it. |
 | [`strategies/`](strategies) | Start with [`starter`](strategies/starter) — the simplest bot, where you edit one `decide()` function. Then full strategies: [market-making](strategies/market-making), [grid](strategies/grid), [momentum](strategies/momentum), [mean-reversion](strategies/mean-reversion), [twap](strategies/twap) (execution algo), and [ensemble](strategies/ensemble) (modular ensemble + optional LLM). Each is clone → configure → run, with its own README explaining the trade-offs. |
-| [`docs/`](docs) | The bot-specific knowledge the protocol docs don't cover: [getting started](docs/getting-started.md), [architecture](docs/architecture.md), [gotchas](docs/gotchas.md), [running 24/7](docs/24-7-operations.md), [session keys](docs/session-keys.md) (run a bot with a hot key that can't withdraw funds). |
+| [`docs/`](docs) | The bot-specific knowledge the protocol docs don't cover: [getting started](docs/getting-started.md), [architecture](docs/architecture.md), [gotchas](docs/gotchas.md), [running 24/7](docs/24-7-operations.md), [session keys](docs/session-keys.md) (run a bot with a hot key that can't withdraw funds), [Railway deploy](docs/railway.md). |
 | [`advanced/batch-7702`](advanced/batch-7702) | A **technique demo** (not a trading strategy): how to use EIP-7702 to batch multiple actions into a single transaction. |
 | [`tools/edge-analytics`](tools/edge-analytics) | An **analysis tool** (not a bot): measures whether a maker actually has an edge — captured spread vs adverse selection vs transactions-per-fill — from your own fills. Methodology in [docs/measuring-edge.md](docs/measuring-edge.md). |
 | [`examples/`](examples) | The real competition bots, sanitized to core code. Different architectures, languages, and tricks — read them to see how people actually did it. |
@@ -94,6 +94,8 @@ python -m bot
 Start on **Shannon testnet** (`NETWORK=testnet`, chain `50312`) with small size before you touch
 mainnet (`5031`). Get testnet funds at [testnet.somnia.network](https://testnet.somnia.network).
 New to all this? Read [docs/getting-started.md](docs/getting-started.md) end to end.
+
+**Deploy on Railway (24/7 worker, no local Node):** see [docs/railway.md](docs/railway.md).
 
 ### Helper scripts
 

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -44,16 +44,19 @@ For DreamDEX maintainers publishing the template:
    - **`PRIVATE_KEY`** — mark **required**, leave default **empty** (user fills at deploy).
    - Or: deploy from GitHub first → **Variables → suggested import** from `.env.railway` → add empty required `PRIVATE_KEY` → **Generate Template from Project**.
 5. **Do not** enable public networking for this service.
-6. Create template, copy the share URL (e.g. `https://railway.com/template/<slug>`).
+6. Create template, copy the share URL (e.g. `https://railway.com/deploy/...`).
 7. Paste that URL into `docs/railway.md` under **Template URL** once live.
 8. Optional: [publish to the marketplace](https://docs.railway.com/templates/publish-and-share).
 
 The Docker image also copies `.env.railway` → `.env`, so a service with **only** `PRIVATE_KEY` set in Railway still gets every other default at runtime.
 
-### Template URL
+### Template URL (demo / test)
 
-<!-- Replace after the template is created in Railway -->
-_TBD — add the Railway template deploy link here._
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/_qTYwR?referralCode=2yBRe7&utm_medium=integration&utm_source=template&utm_campaign=generic)
+
+Deploy link: https://railway.com/deploy/_qTYwR?referralCode=2yBRe7&utm_medium=integration&utm_source=template&utm_campaign=generic
+
+Set **`PRIVATE_KEY`** at deploy time; other defaults come from the template / [`.env.railway`](../.env.railway).
 
 ---
 

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -121,7 +121,14 @@ docker run --rm -e PRIVATE_KEY=0x... -e STRATEGY=starter -e DRY_RUN=true dreamde
 
 ## dreamBot Builder handoff (separate repo)
 
-The builder should add a **Deploy on Railway** button on step 5 that opens the template URL. Pass **non-secret** variables as Railway service defaults (or documented copy-paste list): `STRATEGY`, `NETWORK`, `DRY_RUN`, symbol, and strategy-prefixed knobs. **Never** put `PRIVATE_KEY` in URL query parameters from the DreamDEX site.
+**Recommended Deploy UX (step 5):**
+
+1. User picks strategy / network / knobs in the builder UI (as today).
+2. Builder acts as an **`.env` builder**: generate a Railway-ready env block from those settings (`STRATEGY`, `NETWORK`, `DRY_RUN`, symbol + strategy-prefixed knobs). **Omit `PRIVATE_KEY`.**
+3. Show **Copy env for Railway** (and optionally open the template URL).
+4. User pastes that block into Railway **Variables → RAW Editor**, then sets **only `PRIVATE_KEY`** and deploys.
+
+Template defaults (`.env.railway`) cover the “I skipped the builder” path. Builder-generated env overrides those when pasted. **Never** put `PRIVATE_KEY` in DreamDEX URLs or store it server-side.
 
 ---
 

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -1,0 +1,131 @@
+# Deploy on Railway
+
+Run a DreamDEX bot as an **always-on worker** on [Railway](https://railway.com) — no local Node install or VPS to babysit. This matches the [dreamBot Builder](https://app.dreamdex.io/dreambot-builder) flow: configure strategy and knobs in the UI, then deploy the generated env to Railway instead of cloning locally.
+
+Your **private key never touches DreamDEX**; you paste it only into Railway service variables.
+
+## Features showcased
+
+- **Limit order** / **Market order** (via strategy templates in the kit)
+- **Good-Till-Cancelled (GTC)** / strategy-specific behavior (see each strategy README)
+
+## Learning outcome
+
+You can run any of the six TypeScript builder strategies 24/7 on Railway with safe testnet + dry-run defaults, then flip to mainnet live trading when ready.
+
+## Canonical docs
+
+- [DreamDEX docs](https://docs.dreamdex.io/)
+- [Getting started (wallet, funding)](getting-started.md)
+- [Running 24/7](24-7-operations.md)
+- [Session keys](session-keys.md) (optional; not automated on Railway)
+
+---
+
+## What gets deployed
+
+One Railway **service** (worker):
+
+- Builds from the repo [`Dockerfile`](../Dockerfile) (Node 20, npm workspaces, `@dreamdex-bot-kit/core` + strategies).
+- Runs [`scripts/railway-start.mjs`](../scripts/railway-start.mjs) → `npm run start -w <STRATEGY>`.
+- **No public HTTP** — the bot is a long-running process, not a web app.
+- Restarts on failure (`ON_FAILURE` in [`railway.toml`](../railway.toml)).
+
+---
+
+## One-click template (publish checklist)
+
+For DreamDEX maintainers publishing the template:
+
+1. In Railway: **Workspace → Templates → New Template**.
+2. Add a service sourced from `https://github.com/somnia-chain/dreamdex-bot-kit` (pin branch/tag as needed).
+3. Railway picks up [`railway.toml`](../railway.toml) and the Dockerfile on deploy.
+4. In the template **Variables** tab:
+   - **`PRIVATE_KEY`** — mark **required**, leave default empty (user fills at deploy).
+   - **`STRATEGY`** — default `starter`.
+   - **`NETWORK`** — default `testnet`.
+   - **`DRY_RUN`** — default `true`.
+   - Optional strategy knobs — same names as each strategy’s `.env.example` (see below).
+5. **Do not** enable public networking for this service.
+6. Create template, copy the share URL (e.g. `https://railway.com/template/<slug>`).
+7. Paste that URL into `docs/railway.md` under **Template URL** once live.
+8. Optional: [publish to the marketplace](https://docs.railway.com/templates/publish-and-share).
+
+### Template URL
+
+<!-- Replace after the template is created in Railway -->
+_TBD — add the Railway template deploy link here._
+
+---
+
+## User flow
+
+1. Open the template → **Deploy**.
+2. Set **`PRIVATE_KEY`** (`0x…`; MetaMask exports without `0x` — the start script adds it and logs once).
+3. Set **`STRATEGY`** and tuning vars (or keep defaults).
+4. Deploy → open **Logs** and confirm dry-run lines look right.
+5. Connect the **same wallet** on [Algo Arena](https://app.dreamdex.io/dreambot-builder) so volume counts.
+6. When ready for real trading: set `NETWORK=mainnet`, `DRY_RUN=false` in Railway variables and redeploy.
+
+Fund the bot wallet (SOMI for gas + tokens for the market). See [Getting started § Fund the bot](getting-started.md#4-fund-the-bot).
+
+---
+
+## Environment variables
+
+| Variable | Required | Default | Notes |
+|----------|----------|---------|--------|
+| `PRIVATE_KEY` | Yes | — | Dedicated bot wallet recommended |
+| `STRATEGY` | No | `starter` | `starter`, `market-making`, `grid`, `momentum`, `mean-reversion`, `twap` |
+| `NETWORK` | No | `testnet` | `testnet` or `mainnet` |
+| `DRY_RUN` | No | `true` | `true` / `false` |
+| Strategy knobs | No | code defaults | Same keys as `strategies/<name>/.env.example` |
+
+### Market symbol env names
+
+| `STRATEGY` | Symbol variable |
+|------------|-----------------|
+| `starter` | `SYMBOL` |
+| `market-making` | `MM_SYMBOL` |
+| `grid` | `GRID_SYMBOL` |
+| `momentum` | `MOM_SYMBOL` |
+| `mean-reversion` | `MR_SYMBOL` |
+| `twap` | `TWAP_SYMBOL` |
+
+Railway injects variables into the process; strategies read them via `@dreamdex-bot-kit/core` env loading (no `.env` file required in the container).
+
+Optional overrides: `RPC_URL`, `REST_API_URL`, `WS_URL`, `OWNER_ADDRESS` (session-key mode). See root [`.env.example`](../.env.example).
+
+---
+
+## Local parity (before Railway)
+
+```bash
+npm install
+export PRIVATE_KEY=0x...   # funded testnet key or throwaway for dry-run reads
+export NETWORK=testnet
+export DRY_RUN=true
+export STRATEGY=starter
+npm run railway:start
+```
+
+Docker:
+
+```bash
+docker build -t dreamdex-bot .
+docker run --rm -e PRIVATE_KEY=0x... -e STRATEGY=starter -e DRY_RUN=true dreamdex-bot
+```
+
+---
+
+## dreamBot Builder handoff (separate repo)
+
+The builder should add a **Deploy on Railway** button on step 5 that opens the template URL. Pass **non-secret** variables as Railway service defaults (or documented copy-paste list): `STRATEGY`, `NETWORK`, `DRY_RUN`, symbol, and strategy-prefixed knobs. **Never** put `PRIVATE_KEY` in URL query parameters from the DreamDEX site.
+
+---
+
+## Safety defaults
+
+- Template defaults: **testnet** + **dry-run** (same as the builder).
+- Go live only by explicitly setting `NETWORK=mainnet` and `DRY_RUN=false`.
+- Read [DISCLAIMER](../DISCLAIMER.md) before trading with real funds.

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -52,9 +52,9 @@ The Docker image also copies `.env.railway` → `.env`, so a service with **only
 
 ### Template URL (demo / test)
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/_qTYwR?referralCode=2yBRe7&utm_medium=integration&utm_source=template&utm_campaign=generic)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/_qTYwR)
 
-Deploy link: https://railway.com/deploy/_qTYwR?referralCode=2yBRe7&utm_medium=integration&utm_source=template&utm_campaign=generic
+Deploy link: https://railway.com/deploy/_qTYwR
 
 Set **`PRIVATE_KEY`** at deploy time; other defaults come from the template / [`.env.railway`](../.env.railway).
 

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -40,16 +40,15 @@ For DreamDEX maintainers publishing the template:
 1. In Railway: **Workspace → Templates → New Template**.
 2. Add a service sourced from `https://github.com/somnia-chain/dreamdex-bot-kit` (pin branch/tag as needed).
 3. Railway picks up [`railway.toml`](../railway.toml) and the Dockerfile on deploy.
-4. In the template **Variables** tab:
-   - **`PRIVATE_KEY`** — mark **required**, leave default empty (user fills at deploy).
-   - **`STRATEGY`** — default `starter`.
-   - **`NETWORK`** — default `testnet`.
-   - **`DRY_RUN`** — default `true`.
-   - Optional strategy knobs — same names as each strategy’s `.env.example` (see below).
+4. In the template **Variables** tab, paste the contents of [`.env.railway`](../.env.railway) via **RAW Editor** (all defaults except `PRIVATE_KEY`), then:
+   - **`PRIVATE_KEY`** — mark **required**, leave default **empty** (user fills at deploy).
+   - Or: deploy from GitHub first → **Variables → suggested import** from `.env.railway` → add empty required `PRIVATE_KEY` → **Generate Template from Project**.
 5. **Do not** enable public networking for this service.
 6. Create template, copy the share URL (e.g. `https://railway.com/template/<slug>`).
 7. Paste that URL into `docs/railway.md` under **Template URL** once live.
 8. Optional: [publish to the marketplace](https://docs.railway.com/templates/publish-and-share).
+
+The Docker image also copies `.env.railway` → `.env`, so a service with **only** `PRIVATE_KEY` set in Railway still gets every other default at runtime.
 
 ### Template URL
 
@@ -73,13 +72,15 @@ Fund the bot wallet (SOMI for gas + tokens for the market). See [Getting started
 
 ## Environment variables
 
+Canonical defaults for Railway live in [`.env.railway`](../.env.railway) (committed, no `PRIVATE_KEY`). Import that file in the Railway UI or rely on the baked-in `.env` in the Docker image.
+
 | Variable | Required | Default | Notes |
 |----------|----------|---------|--------|
-| `PRIVATE_KEY` | Yes | — | Dedicated bot wallet recommended |
-| `STRATEGY` | No | `starter` | `starter`, `market-making`, `grid`, `momentum`, `mean-reversion`, `twap` |
-| `NETWORK` | No | `testnet` | `testnet` or `mainnet` |
-| `DRY_RUN` | No | `true` | `true` / `false` |
-| Strategy knobs | No | code defaults | Same keys as `strategies/<name>/.env.example` |
+| `PRIVATE_KEY` | Yes | — | Set only in Railway; never in `.env.railway` |
+| `STRATEGY` | No | `starter` | See `.env.railway` |
+| `NETWORK` | No | `testnet` | |
+| `DRY_RUN` | No | `true` | |
+| Strategy knobs | No | see `.env.railway` | All six builder strategies included |
 
 ### Market symbol env names
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "postinstall": "npm run build",
     "quickstart": "node scripts/quickstart.mjs",
+    "railway:start": "node scripts/railway-start.mjs",
     "build": "npm run build -w @dreamdex-bot-kit/core",
     "typecheck": "npm run build && npm run typecheck --workspaces --if-present"
   }

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,11 @@
+# Railway config for the dreamBot worker template (docs/railway.md).
+# https://docs.railway.com/reference/config-as-code
+
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+startCommand = "node scripts/railway-start.mjs"
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10

--- a/scripts/railway-start.mjs
+++ b/scripts/railway-start.mjs
@@ -1,0 +1,78 @@
+/**
+ * Railway worker entrypoint: pick STRATEGY, validate PRIVATE_KEY, run npm start for that workspace.
+ */
+
+import { spawn } from "node:child_process";
+
+const ALLOWED = new Set([
+  "starter",
+  "market-making",
+  "grid",
+  "momentum",
+  "mean-reversion",
+  "twap",
+]);
+
+function normalizePrivateKey(raw) {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (/^0x[0-9a-fA-F]+$/.test(trimmed)) return trimmed;
+  if (/^[0-9a-fA-F]+$/.test(trimmed)) {
+    console.log("[railway-start] Added 0x prefix to PRIVATE_KEY (MetaMask-style export).");
+    return `0x${trimmed}`;
+  }
+  throw new Error("PRIVATE_KEY must be a hex string (with or without 0x prefix).");
+}
+
+function main() {
+  const strategy = (process.env.STRATEGY ?? "starter").trim();
+  if (!ALLOWED.has(strategy)) {
+    console.error(
+      `[railway-start] Unknown STRATEGY="${strategy}". Allowed: ${[...ALLOWED].join(", ")}`,
+    );
+    process.exit(1);
+  }
+
+  const keyRaw = process.env.PRIVATE_KEY;
+  if (!keyRaw?.trim()) {
+    console.error("[railway-start] Set PRIVATE_KEY in Railway service variables (never commit it).");
+    process.exit(1);
+  }
+
+  let privateKey;
+  try {
+    privateKey = normalizePrivateKey(keyRaw);
+  } catch (err) {
+    console.error(`[railway-start] ${err.message}`);
+    process.exit(1);
+  }
+
+  process.env.PRIVATE_KEY = privateKey;
+
+  const network = process.env.NETWORK ?? "testnet";
+  const dryRun = process.env.DRY_RUN ?? "true";
+  console.log(
+    `[railway-start] strategy=${strategy} network=${network} dryRun=${dryRun} wallet=derived-from-key`,
+  );
+
+  const child = spawn("npm", ["run", "start", "-w", strategy], {
+    stdio: "inherit",
+    env: process.env,
+    shell: false,
+  });
+
+  child.on("error", (err) => {
+    console.error(`[railway-start] Failed to spawn npm: ${err.message}`);
+    process.exit(1);
+  });
+
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      console.error(`[railway-start] npm exited on signal ${signal}`);
+      process.exit(1);
+    }
+    process.exit(code ?? 1);
+  });
+}
+
+main();

--- a/scripts/railway-start.mjs
+++ b/scripts/railway-start.mjs
@@ -1,4 +1,12 @@
 /**
+ * @license
+ * Copyright DreamDEX S.A.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/somnia-chain/dreamdex-bot-kit/blob/main/LICENSE
+ */
+
+/**
  * Railway worker entrypoint: pick STRATEGY, validate PRIVATE_KEY, run npm start for that workspace.
  */
 
@@ -60,6 +68,12 @@ function main() {
     env: process.env,
     shell: false,
   });
+
+  const forward = (signal) => {
+    if (child.pid) child.kill(signal);
+  };
+  process.on("SIGTERM", () => forward("SIGTERM"));
+  process.on("SIGINT", () => forward("SIGINT"));
 
   child.on("error", (err) => {
     console.error(`[railway-start] Failed to spawn npm: ${err.message}`);


### PR DESCRIPTION
## Summary

- Adds a Docker + `railway.toml` worker path so Algo Arena users can run builder strategies 24/7 on Railway without local Node/VPS setup.
- Introduces `scripts/railway-start.mjs` (`STRATEGY` allowlist, `PRIVATE_KEY` + `0x` normalize, `npm run start -w <strategy>`) and committed `.env.railway` defaults (all knobs except `PRIVATE_KEY`), baked into the image as `.env`.
- Documents publish checklist, env contract, and dreamBot Builder handoff in `docs/railway.md`.

## Demo / test deploy

Try the template from this branch:

[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/_qTYwR)

https://railway.com/deploy/_qTYwR

Set **`PRIVATE_KEY`** at deploy; defaults are testnet + dry-run + starter (or paste builder-generated env into RAW Editor).

## Frontend follow-up (required for full UX)

This kit alone ships **static** Railway defaults. For the intended product flow — tune strategy/params in the dreamBot Builder UI, then deploy with almost no Railway config — the **frontend needs an `.env` builder**:

1. From the user’s Strategy / Network / Tune choices, generate a Railway-ready env block (`STRATEGY`, `NETWORK`, `DRY_RUN`, symbol, strategy-prefixed knobs).
2. **Do not include `PRIVATE_KEY`.**
3. On Deploy: **Copy env for Railway** (and optionally open the template URL).
4. User pastes that block into Railway **Variables → RAW Editor**, then pastes **only `PRIVATE_KEY`**, then deploys.

Until that Builder work lands, users can still deploy from template defaults (starter / testnet / dry-run) and edit vars manually in Railway.

## Test plan

- [ ] `node scripts/railway-start.mjs` without `PRIVATE_KEY` exits 1 with a clear message
- [ ] Invalid `STRATEGY` exits 1 listing allowed strategies
- [ ] `docker build -t dreamdex-bot .` succeeds
- [ ] `docker run --rm -e PRIVATE_KEY=0x… -e STRATEGY=starter -e DRY_RUN=true -e NETWORK=testnet dreamdex-bot` logs dry-run quotes
- [ ] Key without `0x` gets a one-time normalize log and still starts
- [ ] (Manual) Deploy branch on Railway with only `PRIVATE_KEY` set; confirm defaults from baked `.env` / imported `.env.railway`
- [ ] (Manual) One-click deploy via link above
